### PR TITLE
Migrate from logrus to zap

### DIFF
--- a/alert/alert.go
+++ b/alert/alert.go
@@ -1,10 +1,9 @@
 package alert
 
-import logger "github.com/sirupsen/logrus"
+// ALERT_PREFIX is added to log messages that should be forwarded to Telegram.
+const ALERT_PREFIX = "[ALERT]"
 
-const ALERT_MARKER = "ALERT_MARKER"
-const ALERT_VALUE = "TELEGRAM"
-
-func Log() *logger.Entry {
-	return logger.WithField(ALERT_MARKER, ALERT_VALUE)
+// Prefix prepends ALERT_PREFIX to the provided message.
+func Prefix(msg string) string {
+	return ALERT_PREFIX + " " + msg
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,26 +1,27 @@
 package main
 
 import (
-	log "github.com/sirupsen/logrus"
 	"telegram-alerts-go/alert"
 	"telegram-alerts-go/config"
 	"telegram-alerts-go/loghook"
 	"telegram-alerts-go/telegram"
+
+	"go.uber.org/zap"
 )
 
 func main() {
-
 	cfg := config.LoadFromEnv()
 
 	client := telegram.NewClient(cfg.BotToken, cfg.ChannelID)
-	hook := loghook.NewTelegramHook(client, cfg.ServiceName)
-	log.AddHook(hook)
 
-	log.SetFormatter(&log.TextFormatter{FullTimestamp: true})
+	logger, _ := zap.NewProduction()
+	defer logger.Sync()
+
+	logger = logger.WithOptions(loghook.NewTelegramHook(client, cfg.ServiceName))
 
 	// Обычный лог
-	log.Info("Service started")
+	logger.Info("Service started")
 
 	// АЛЕРТ-лог
-	alert.Log().Error("Test GO Telegram Alert")
+	logger.Error(alert.Prefix("Test GO Telegram Alert"))
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module telegram-alerts-go
 
 go 1.24.1
 
-require github.com/sirupsen/logrus v1.9.3
+require go.uber.org/zap v1.26.0
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+

--- a/go.sum
+++ b/go.sum
@@ -3,13 +3,9 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- migrate logging to zap
- send Telegram alerts when message has `[ALERT]` prefix
- update example and README

## Testing
- `go vet ./...` *(fails: missing go.sum entry for go.uber.org/zap)*
- `go build ./...` *(fails: missing go.sum entry for go.uber.org/zap)*

------
https://chatgpt.com/codex/tasks/task_e_684fe15c0c3c832cb624aaf140b8d0f4