### PR TITLE
Add optional Telegram hook with config check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ import (
     "telegram-alerts-go/alert"
     "telegram-alerts-go/config"
     "telegram-alerts-go/loghook"
-    "telegram-alerts-go/telegram"
 
     "go.uber.org/zap"
 )
@@ -36,19 +35,21 @@ import (
 func main() {
     cfg := config.LoadFromEnv()
 
-    client := telegram.NewClient(cfg.BotToken, cfg.ChannelID)
     logger, _ := zap.NewProduction()
     defer logger.Sync()
 
-    logger = logger.WithOptions(loghook.NewTelegramHook(client, cfg.ServiceName))
+    logger = loghook.AttachToLogger(logger, cfg)
 
     // Regular log message
     logger.Info("Service started")
 
     // Alert log message
-    logger.Error(alert.Prefix("Database is down!"))
+logger.Error(alert.Prefix("Database is down!"))
 }
 ```
+
+`AttachToLogger` checks that the required environment variables are set. If any
+are missing, it logs a warning and disables Telegram forwarding.
 
 ## Environment variables
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,24 @@ type Config struct {
 	ServiceName string
 }
 
+// MissingFields returns names of the environment variables that were not set.
+func (c *Config) MissingFields() []string {
+	missing := []string{}
+	if c.BotToken == "" {
+		missing = append(missing, "BOT_TOKEN")
+	}
+	if c.ChannelID == "" {
+		missing = append(missing, "CHANNEL_ID")
+	}
+	if c.ServiceName == "" {
+		missing = append(missing, "SERVICE_NAME")
+	}
+	if c.BotUsername == "" {
+		missing = append(missing, "BOT_USERNAME")
+	}
+	return missing
+}
+
 func LoadFromEnv() *Config {
 	return &Config{
 		BotUsername: os.Getenv("BOT_USERNAME"),

--- a/examples/main.go
+++ b/examples/main.go
@@ -4,7 +4,6 @@ import (
 	"telegram-alerts-go/alert"
 	"telegram-alerts-go/config"
 	"telegram-alerts-go/loghook"
-	"telegram-alerts-go/telegram"
 
 	"go.uber.org/zap"
 )
@@ -12,12 +11,10 @@ import (
 func main() {
 	cfg := config.LoadFromEnv()
 
-	client := telegram.NewClient(cfg.BotToken, cfg.ChannelID)
-
 	logger, _ := zap.NewProduction()
 	defer logger.Sync()
 
-	logger = logger.WithOptions(loghook.NewTelegramHook(client, cfg.ServiceName))
+	logger = loghook.AttachToLogger(logger, cfg)
 
 	// Обычный лог
 	logger.Info("Service started")


### PR DESCRIPTION
## Summary
- add `MissingFields` helper to config
- implement `AttachToLogger` that warns when Telegram isn't configured
- update example to use the new helper
- document usage in README

## Testing
- `go vet -mod=mod ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: missing go.sum entry for zap packages)*

------
https://chatgpt.com/codex/tasks/task_e_684ffdcc7d98832c8bbbe3b6275f12fc